### PR TITLE
Added support for gradle javadocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /build
 /captures
 .externalNativeBuild
+
+javadoc/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,3 +43,17 @@ dependencies {
     compile 'com.android.support:design:23.4.0'
     testCompile 'junit:junit:4.12'
 }
+
+task javadoc(type: Javadoc) {
+    source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    println(android.getBootClasspath())
+    destinationDir = file("../javadoc/")
+    failOnError false
+}
+
+afterEvaluate {
+    javadoc.classpath += files(android.applicationVariants.collect { variant ->
+        variant.javaCompile.classpath.files
+    })
+}


### PR DESCRIPTION
Run ./gradlew javadoc to generate. They can be found in /javadoc/